### PR TITLE
Update the Twitch link for Jochen Lillich

### DIFF
--- a/README.md
+++ b/README.md
@@ -723,7 +723,7 @@ AWS, Web Development, Python, Serverless, AI
 - DevOps - Chef, Docker, Kontena
 - Ruby programming
 #### Streaming on:
-- [Twitch](https://www.twitch.tv/dev0ps)
+- [Twitch](https://www.twitch.tv/fullstacklive)
 #### Languages Spoken During Stream
 - English
 #### Links:


### PR DESCRIPTION
The Twitch page of Jochen Lillich has been rebranded from dev0ps to fullstacklive